### PR TITLE
feat: 계좌 정산 기초 틀 작성

### DIFF
--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/AccountBalanceSnapshot.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/AccountBalanceSnapshot.java
@@ -1,0 +1,30 @@
+package com.taesan.tikkle.domain.account.entity;
+
+import com.taesan.tikkle.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "account_balance_snapshot")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AccountBalanceSnapshot extends BaseEntity {
+
+    @Id
+    private UUID id;
+
+    // 계좌 ID 이외의 정보는 필요하지 않으므로 Id만 이용
+    @Column(nullable = false)
+    private UUID accountId;
+
+    @Column(nullable = false)
+    private int balance;
+
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/BalanceSnapshot.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/BalanceSnapshot.java
@@ -1,11 +1,13 @@
 package com.taesan.tikkle.domain.account.entity;
 
+import com.taesan.tikkle.domain.member.entity.Member;
 import com.taesan.tikkle.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,5 +28,11 @@ public class BalanceSnapshot extends BaseEntity {
 
     @Column(nullable = false)
     private int balance;
+
+    @Builder
+    private BalanceSnapshot(UUID accountId, int balance) {
+        this.accountId = accountId;
+        this.balance = balance;
+    }
 
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/BalanceSnapshot.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/BalanceSnapshot.java
@@ -27,12 +27,16 @@ public class BalanceSnapshot extends BaseEntity {
     private UUID accountId;
 
     @Column(nullable = false)
-    private int balance;
+    private int timeQnt;
+
+    @Column(nullable = false)
+    private int rankingPoint;
 
     @Builder
-    private BalanceSnapshot(UUID accountId, int balance) {
+    private BalanceSnapshot(UUID accountId, int timeQnt, int rankingPoint) {
         this.accountId = accountId;
-        this.balance = balance;
+        this.timeQnt = timeQnt;
+        this.rankingPoint = rankingPoint;
     }
 
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/BalanceSnapshot.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/entity/BalanceSnapshot.java
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
 import java.util.UUID;
 
 @Entity
-@Table(name = "account_balance_snapshot")
+@Table(name = "balance_snapshot")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AccountBalanceSnapshot extends BaseEntity {
+public class BalanceSnapshot extends BaseEntity {
 
     @Id
     private UUID id;

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotRepository.java
@@ -1,0 +1,12 @@
+package com.taesan.tikkle.domain.account.repository;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BalanceSnapshotRepository extends JpaRepository<BalanceSnapshot, UUID> {
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotRepository.java
@@ -5,8 +5,12 @@ import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface BalanceSnapshotRepository extends JpaRepository<BalanceSnapshot, UUID> {
+
+    Optional<BalanceSnapshot> findFirstByAccountIdOrderByCreatedAtDesc(UUID accountId);
+
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/ExchangeRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/ExchangeRepository.java
@@ -1,5 +1,7 @@
 package com.taesan.tikkle.domain.account.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +11,6 @@ import com.taesan.tikkle.domain.account.entity.ExchangeLog;
 
 @Repository
 public interface ExchangeRepository extends JpaRepository<ExchangeLog, UUID> {
+
+    List<ExchangeLog> findByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
@@ -70,10 +70,10 @@ public class SettlementService {
             for (ExchangeLog log : accountLogs) {
                 if (log.getExchangeType() == ExchangeType.TTOR) {
                     historicalTQ -= log.getQuantity();
-                    historicalRP += log.getQuantity();
+                    historicalRP += log.getQuantity() * log.getRate().getTimeToRank();
                 } else if (log.getExchangeType() == ExchangeType.RTOT) {
                     historicalTQ += log.getQuantity();
-                    historicalRP -= log.getQuantity();
+                    historicalRP -= log.getQuantity() * log.getRate().getTimeToRank();
                 }
             }
 

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
@@ -1,0 +1,80 @@
+package com.taesan.tikkle.domain.account.service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.taesan.tikkle.domain.account.dto.ExchangeType;
+import com.taesan.tikkle.domain.config.security.CustomUserDetails;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import com.taesan.tikkle.domain.account.entity.ExchangeLog;
+import com.taesan.tikkle.domain.account.repository.ExchangeRepository;
+import com.taesan.tikkle.domain.account.repository.AccountRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/*
+ *  TODO: 랭킹 포인트 검증 로직 추가 필요
+ * 
+ */
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+
+    private final AccountRepository accountRepository;
+    private final ExchangeRepository exchangeRepository;
+    private static final Logger logger = LoggerFactory.getLogger(SettlementService.class);
+
+
+    @Transactional
+    public boolean performDailySettlement() {
+        boolean isFlawless = true;
+
+        LocalDate today = LocalDate.now();
+
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 29, 59);
+
+        List<ExchangeLog> exchangeLogs = exchangeRepository.findByCreatedAtBetween(startOfDay, endOfDay);
+        List<Account> accounts = accountRepository.findAll();
+
+        Map<UUID, List<ExchangeLog>> accountLogsMap = exchangeLogs.stream()
+                .collect(Collectors.groupingBy(log -> log.getAccount().getId()));
+
+        for (Account account : accounts) {
+            List<ExchangeLog> accountLogs = accountLogsMap.get(account.getId());
+
+            if (accountLogs == null) {
+                continue;
+            }
+
+            int expectedTimeQnt = account.getTimeQnt();  // 예상되는 잔액
+            for (ExchangeLog log : accountLogs) {
+                if (log.getExchangeType() == ExchangeType.TTOR) {
+                    expectedTimeQnt -= log.getQuantity();
+                } else if (log.getExchangeType() == ExchangeType.RTOT) {
+                    expectedTimeQnt += log.getQuantity();
+                }
+            }
+
+            if (account.getTimeQnt() != expectedTimeQnt) {
+                logger.error("Account balance mismatch for accountId {}: expected (timeQnt={}, ), actual (timeQnt={}, rankingPoint={})",
+                        account.getId(), expectedTimeQnt,
+                        account.getTimeQnt(), account.getRankingPoint());
+                isFlawless = false;
+            }
+        }
+
+        return isFlawless;
+    }
+}
+

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
@@ -87,7 +87,7 @@ public class SettlementService {
             if (account.getRankingPoint() != historicalRP) {
                 logger.error("Account balance mismatch for accountId {}: expected (RankingPoint={}, ), actual (timeQnt={}, rankingPoint={})",
                         account.getId(), historicalRP,
-                        account.getRankingPoint(), account.getRankingPoint());
+                        account.getTimeQnt(), account.getRankingPoint());
                 isFlawless = false;
             }
 

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SettlementService.java
@@ -25,7 +25,7 @@ import com.taesan.tikkle.domain.account.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
 
 /*
- *  TODO: 랭킹 포인트 검증 로직 추가 필요
+ *  TODO: 정산 후 BalanceSnapshot 엔티티 생성 메서드 필요
  * 
  */
 @Service

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/member/service/CustomOAuth2UserService.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/member/service/CustomOAuth2UserService.java
@@ -125,7 +125,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 			BalanceSnapshot snapshot = BalanceSnapshot.builder()
 					.accountId(account.getId())
-					.balance(account.getTimeQnt())
+					.timeQnt(account.getTimeQnt())
+					.rankingPoint(account.getRankingPoint())
 					.build();
 
 			balanceSnapshotRepository.save(snapshot);

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/member/service/CustomOAuth2UserService.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/member/service/CustomOAuth2UserService.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
+import com.taesan.tikkle.domain.account.repository.BalanceSnapshotRepository;
 import com.taesan.tikkle.domain.member.entity.Role;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +50,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 	private final OrganizationRepository organizationRepository;
 	private final AccountRepository accountRepository;
 	private final OAuth2AuthorizedClientService authorizedClientService;
+	private final BalanceSnapshotRepository balanceSnapshotRepository;
 
 	@Value("${file.upload.image-dir}")
 	private String imageUploadDir;
@@ -119,6 +122,13 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
 			// Account 저장
 			accountRepository.save(account);
+
+			BalanceSnapshot snapshot = BalanceSnapshot.builder()
+					.accountId(account.getId())
+					.balance(account.getTimeQnt())
+					.build();
+
+			balanceSnapshotRepository.save(snapshot);
 
 			return savedMember;
 

--- a/back/tikkle/src/test/java/com/taesan/tikkle/domain/account/SettlementServiceTest.java
+++ b/back/tikkle/src/test/java/com/taesan/tikkle/domain/account/SettlementServiceTest.java
@@ -1,0 +1,203 @@
+package com.taesan.tikkle.domain.account;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
+import com.taesan.tikkle.domain.account.entity.ExchangeLog;
+import com.taesan.tikkle.domain.account.dto.ExchangeType;
+import com.taesan.tikkle.domain.account.repository.AccountRepository;
+import com.taesan.tikkle.domain.account.repository.BalanceSnapshotRepository;
+import com.taesan.tikkle.domain.account.repository.ExchangeRepository;
+import com.taesan.tikkle.domain.account.service.SettlementService;
+import com.taesan.tikkle.domain.rate.entity.Rate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SettlementServiceTest {
+
+    @InjectMocks
+    private SettlementService settlementService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private ExchangeRepository exchangeRepository;
+
+    @Mock
+    private BalanceSnapshotRepository balanceSnapshotRepository;
+
+    private UUID accountId;
+    private Account account;
+    private ExchangeLog exchangeLog;
+    private Rate rate;
+    private BalanceSnapshot balanceSnapshot;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        account = Account.builder()
+                .timeQnt(10)
+                .build();
+        accountId = account.getId();
+
+        rate = Rate.builder()
+                .timeToRank(1000)
+                .build();
+
+        exchangeLog = ExchangeLog.builder()
+                .account(account)
+                .quantity(1)
+                .exchangeType(ExchangeType.TTOR)
+                .rate(rate)
+                .build();
+
+        balanceSnapshot = BalanceSnapshot.builder()
+                .accountId(accountId)
+                .timeQnt(10)
+                .rankingPoint(0)
+                .build();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_AccountBalanceMatches() {
+        // Given
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 29, 59);
+
+        List<ExchangeLog> exchangeLogs = Arrays.asList(exchangeLog);
+        List<Account> accounts = Arrays.asList(account);
+
+        account.updateAccount(exchangeLog.getExchangeType(),
+                exchangeLog.getRate().getTimeToRank(),
+                exchangeLog.getQuantity());
+
+        when(exchangeRepository.findByCreatedAtBetween(startOfDay, endOfDay)).thenReturn(exchangeLogs);
+        when(accountRepository.findAll()).thenReturn(accounts);
+        when(balanceSnapshotRepository
+                .findFirstByAccountIdOrderByCreatedAtDesc(account.getId()))
+                .thenReturn(Optional.ofNullable(balanceSnapshot));
+
+        // When
+        boolean result = settlementService.performDailySettlement();
+
+        // Then: 계좌 잔액이 일치하므로 true를 반환해야 함
+        assertTrue(result);
+    }
+
+    @Test
+    public void should_ReturnFalse_When_AccountBalanceDoesNotMatch() {
+        // Given: 예상되는 잔액과 실제 잔액이 다를 때
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 29, 59);
+
+        // mockAccount의 timeQnt를 10에서 0으로 설정했으나, 로그에서 1이 감소되므로 mismatch 발생
+        account.updateAccount(exchangeLog.getExchangeType(),
+                exchangeLog.getRate().getTimeToRank(),
+                10);
+
+        List<ExchangeLog> exchangeLogs = Arrays.asList(exchangeLog);
+        List<Account> accounts = Arrays.asList(account);
+
+        when(exchangeRepository.findByCreatedAtBetween(startOfDay, endOfDay)).thenReturn(exchangeLogs);
+        when(accountRepository.findAll()).thenReturn(accounts);
+        when(balanceSnapshotRepository
+                .findFirstByAccountIdOrderByCreatedAtDesc(account.getId()))
+                .thenReturn(Optional.ofNullable(balanceSnapshot));
+
+        // When
+        boolean result = settlementService.performDailySettlement();
+
+        // Then: 계좌 잔액이 불일치하므로 false를 반환해야 함
+        assertFalse(result);
+    }
+
+    @Test
+    public void should_ReturnTrue_When_NoExchangeLogsExist() {
+        // Given: ExchangeLog가 없을 때
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 29, 59);
+
+        List<ExchangeLog> exchangeLogs = Arrays.asList();
+        List<Account> accounts = Arrays.asList(account);
+
+        when(exchangeRepository.findByCreatedAtBetween(startOfDay, endOfDay)).thenReturn(exchangeLogs);
+        when(accountRepository.findAll()).thenReturn(accounts);
+        when(balanceSnapshotRepository
+                .findFirstByAccountIdOrderByCreatedAtDesc(account.getId()))
+                .thenReturn(Optional.ofNullable(balanceSnapshot));
+
+        // When
+        boolean result = settlementService.performDailySettlement();
+
+        // Then: ExchangeLog가 없으면 잔액 비교가 불필요하므로 true 반환
+        assertTrue(result);
+    }
+
+    @Test
+    public void should_HandleMultipleAccountsWithDifferentExchangeLogs() {
+        // Given: 여러 계좌와 ExchangeLog가 있을 때
+        Account anotherAccount = Account.builder()
+                .timeQnt(10)
+                .build();
+
+        ExchangeLog anotherExchangeLog = ExchangeLog.builder()
+                .account(anotherAccount)
+                .quantity(2)
+                .exchangeType(ExchangeType.TTOR)
+                .rate(rate)
+                .build();
+
+        BalanceSnapshot anotherSnapshot = BalanceSnapshot.builder()
+                .accountId(anotherAccount.getId())
+                .timeQnt(10)
+                .rankingPoint(0)
+                .build();
+
+        account.updateAccount(exchangeLog.getExchangeType(),
+                exchangeLog.getRate().getTimeToRank(),
+                exchangeLog.getQuantity());
+
+        anotherAccount.updateAccount(anotherExchangeLog.getExchangeType(),
+                anotherExchangeLog.getRate().getTimeToRank(),
+                anotherExchangeLog.getQuantity());
+
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(23, 29, 59);
+
+        List<ExchangeLog> exchangeLogs = Arrays.asList(exchangeLog, anotherExchangeLog);
+        List<Account> accounts = Arrays.asList(account, anotherAccount);
+
+        when(exchangeRepository.findByCreatedAtBetween(startOfDay, endOfDay)).thenReturn(exchangeLogs);
+        when(accountRepository.findAll()).thenReturn(accounts);
+        when(balanceSnapshotRepository
+                .findFirstByAccountIdOrderByCreatedAtDesc(account.getId()))
+                .thenReturn(Optional.ofNullable(balanceSnapshot));
+        when(balanceSnapshotRepository
+                .findFirstByAccountIdOrderByCreatedAtDesc(anotherAccount.getId()))
+                .thenReturn(Optional.ofNullable(anotherSnapshot));
+
+        // When
+        boolean result = settlementService.performDailySettlement();
+
+        // Then: 모든 계좌의 잔액이 일치하면 true를 반환해야 함
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
[feat: 당일 exchange 로그 검색을 위한 쿼리](https://github.com/tikkle-a501/tikkle/commit/df89651550962e7642ff0ec6f5e7ee7a49902bcb)

[feat: 당일 계좌 환전 정산 로직](https://github.com/tikkle-a501/tikkle/commit/18fa06e94a8a8c9227f6fbf3e90ed25cca371eb8)
- 필요: 직전 balance 기준 계산, 랭킹 포인트 정산

[feat: 계좌 잔액 스냅샷 엔티티 추가](https://github.com/tikkle-a501/tikkle/commit/3d8a813c67a3f9fcc5a3bc277dadc37507e65345)
- 직전 balance 기록을 위한 entity
- 가입 시 첫날은 balance와 동일한 기본값