### PR TITLE
feat: 계좌 스냅샷 생성 관련 전략 패턴 작성

### DIFF
--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepository.java
@@ -1,0 +1,9 @@
+package com.taesan.tikkle.domain.account.repository;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+
+import java.util.stream.Stream;
+
+public interface AccountCustomRepository {
+    Stream<Account> findAllWithStream(int fetchSize);
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepositoryImpl.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepositoryImpl.java
@@ -10,6 +10,9 @@ import java.util.stream.Stream;
 import static org.hibernate.annotations.QueryHints.READ_ONLY;
 import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
+/*
+    테스트 비교를 위한 클래스이므로, 로직 확정 전까지는 AccountCustom... 으로 고수
+ */
 @Repository
 public class AccountCustomRepositoryImpl implements AccountCustomRepository {
 

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepositoryImpl.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepositoryImpl.java
@@ -3,12 +3,14 @@ package com.taesan.tikkle.domain.account.repository;
 import com.taesan.tikkle.domain.account.entity.Account;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
 
 import java.util.stream.Stream;
 
 import static org.hibernate.annotations.QueryHints.READ_ONLY;
 import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
+@Repository
 public class AccountCustomRepositoryImpl implements AccountCustomRepository {
 
     @PersistenceContext

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepositoryImpl.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountCustomRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.taesan.tikkle.domain.account.repository;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import java.util.stream.Stream;
+
+import static org.hibernate.annotations.QueryHints.READ_ONLY;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
+
+public class AccountCustomRepositoryImpl implements AccountCustomRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Stream<Account> findAllWithStream(int fetchSize) {
+        return entityManager.createQuery("SELECT a FROM Account a", Account.class)
+                .setHint(HINT_FETCH_SIZE, fetchSize)
+                .setHint(READ_ONLY, true)
+                .getResultStream();
+    }
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountRepository.java
@@ -37,11 +37,4 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
 	List<ExchangeLog> findExchangeLogsByMemberId(@Param("memberId") UUID memberId);
 
 	Optional<Account> findByMemberIdAndDeletedAtIsNull(UUID id);
-
-	@QueryHints(value = {
-			@QueryHint(name = HINT_FETCH_SIZE, value = "" + 1000),
-			@QueryHint(name = READ_ONLY, value = "true")
-	})
-	@Query("SELECT a FROM Account a")
-	Stream<Account> findAllAccounts();
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountRepository.java
@@ -4,15 +4,21 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.taesan.tikkle.domain.account.dto.ExchangeType;
 import com.taesan.tikkle.domain.account.entity.Account;
 import com.taesan.tikkle.domain.account.entity.ExchangeLog;
+
+import static org.hibernate.annotations.QueryHints.READ_ONLY;
+import static org.hibernate.jpa.HibernateHints.HINT_FETCH_SIZE;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, UUID> {
@@ -31,4 +37,11 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
 	List<ExchangeLog> findExchangeLogsByMemberId(@Param("memberId") UUID memberId);
 
 	Optional<Account> findByMemberIdAndDeletedAtIsNull(UUID id);
+
+	@QueryHints(value = {
+			@QueryHint(name = HINT_FETCH_SIZE, value = "" + 1000),
+			@QueryHint(name = READ_ONLY, value = "true")
+	})
+	@Query("SELECT a FROM Account a")
+	Stream<Account> findAllAccounts();
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/AccountRepository.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import jakarta.persistence.QueryHint;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
@@ -37,4 +39,6 @@ public interface AccountRepository extends JpaRepository<Account, UUID> {
 	List<ExchangeLog> findExchangeLogsByMemberId(@Param("memberId") UUID memberId);
 
 	Optional<Account> findByMemberIdAndDeletedAtIsNull(UUID id);
+
+	Slice<Account> findAllAsSlice(Pageable pageable);
 }

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotCustomRepository.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotCustomRepository.java
@@ -1,0 +1,5 @@
+package com.taesan.tikkle.domain.account.repository;
+
+public interface BalanceSnapshotCustomRepository {
+    int insertDirectlyFromAccounts();
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotCustomRepositoryImpl.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/repository/BalanceSnapshotCustomRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.taesan.tikkle.domain.account.repository;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BalanceSnapshotCustomRepositoryImpl implements BalanceSnapshotCustomRepository {
+
+    private final JdbcClient jdbcClient;
+    private static final Logger logger = LoggerFactory.getLogger(BalanceSnapshotCustomRepositoryImpl.class);
+
+    public BalanceSnapshotCustomRepositoryImpl(JdbcClient jdbcClient) {
+        this.jdbcClient = jdbcClient;
+    }
+
+    @Override
+    public int insertDirectlyFromAccounts() {
+        logger.info("Starting INSERT INTO SELECT of balance snapshots directly from account table");
+
+        // INSERT INTO SELECT 문으로 애플리케이션 메모리 사용 없이 DB 내부에서 직접 데이터 변환 및 삽입
+        int rowsAffected = jdbcClient.sql(
+                        "INSERT INTO balance_snapshot (id, account_id, time_qnt, ranking_point, created_at) " +
+                        "SELECT " +
+                        "  CONCAT(UNHEX(LPAD(HEX(ROUND(UNIX_TIMESTAMP(NOW(3)) * 1000)), 12, '0')), RANDOM_BYTES(10)), " +
+                        "  id, time_qnt, ranking_point, NOW() " +
+                        "FROM accounts")
+                    .update();
+
+        logger.info("INSERT INTO SELECT completed, inserted {} records", rowsAffected);
+
+        return rowsAffected;
+    }
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/JpaSnapshotStrategy.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/JpaSnapshotStrategy.java
@@ -1,0 +1,40 @@
+package com.taesan.tikkle.domain.account.service;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
+import com.taesan.tikkle.domain.account.repository.AccountRepository;
+import com.taesan.tikkle.domain.account.repository.BalanceSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component("jpaSnapshotStrategy")
+@RequiredArgsConstructor
+public class JpaSnapshotStrategy implements SnapshotStrategy {
+
+    private final AccountRepository accountRepository;
+    private final BalanceSnapshotRepository balanceSnapshotRepository;
+    private static final Logger logger = LoggerFactory.getLogger(JpaSnapshotStrategy.class);
+
+    @Override
+    public void createSnapShots() {
+        List<Account> accounts = accountRepository.findAll();
+        List<BalanceSnapshot> snapshots = accounts.stream()
+                .map(account -> BalanceSnapshot.builder()
+                        .accountId(account.getId())
+                        .timeQnt(account.getTimeQnt())
+                        .rankingPoint(account.getRankingPoint())
+                        .build())
+                .toList();
+
+        balanceSnapshotRepository.saveAll(snapshots);
+    }
+
+    @Override
+    public String getStrategyName() {
+        return SnapshotStrategyType.JPA.getDescription();
+    }
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/PagingSnapshotStrategy.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/PagingSnapshotStrategy.java
@@ -1,0 +1,83 @@
+package com.taesan.tikkle.domain.account.service;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
+import com.taesan.tikkle.domain.account.repository.AccountRepository;
+import com.taesan.tikkle.domain.account.repository.BalanceSnapshotRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component("pagingSnapshotStrategy")
+@RequiredArgsConstructor
+public class PagingSnapshotStrategy implements SnapshotStrategy {
+
+    private final AccountRepository accountRepository;
+    private final BalanceSnapshotRepository balanceSnapshotRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private static final Logger logger = LoggerFactory.getLogger(PagingSnapshotStrategy.class);
+
+    @Override
+    @Transactional
+    public void createSnapShots() {
+
+        logger.info("Creating snapshots using Paging strategy");
+
+        int pageSize = 1000;
+        int pageNumber = 0;
+        int totalProcessed = 0;
+        boolean hasMoreData = true;
+
+        while (hasMoreData) {
+            Pageable pageable = PageRequest.of(pageNumber, pageSize);
+            Page<Account> accountPage = accountRepository.findAll(pageable);
+
+            // 스냅샷 생성 및 저장
+            List<BalanceSnapshot> batchSnapshots = accountPage.getContent().stream()
+                    .map(this::convertToSnapshot)
+                    .collect(Collectors.toList());
+
+            balanceSnapshotRepository.saveAll(batchSnapshots);
+
+            entityManager.flush();
+            entityManager.clear();
+
+            totalProcessed += batchSnapshots.size();
+            logger.debug("Processed page {} with {} accounts", pageNumber, batchSnapshots.size());
+
+            pageNumber++;
+            hasMoreData = !accountPage.isLast();
+        }
+
+        logger.info("Created {} snapshots using Paging strategy", totalProcessed);
+    }
+
+    @Override
+    public String getStrategyName() {
+        return SnapshotStrategyType.PAGING.getDescription();
+    }
+
+    private BalanceSnapshot convertToSnapshot(Account account) {
+        return BalanceSnapshot.builder()
+                .accountId(account.getId())
+                .timeQnt(account.getTimeQnt())
+                .rankingPoint(account.getRankingPoint())
+                .build();
+    }
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SnapshotStrategy.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SnapshotStrategy.java
@@ -1,0 +1,6 @@
+package com.taesan.tikkle.domain.account.service;
+
+public interface SnapshotStrategy {
+    void createSnapShots();
+    String getStrategyName();
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SnapshotStrategyType.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/SnapshotStrategyType.java
@@ -1,0 +1,24 @@
+package com.taesan.tikkle.domain.account.service;
+
+public enum SnapshotStrategyType {
+    JPA("JPA findAll()", "jpaSnapshotStrategy"),
+    STREAM("STREAM API", "streamSnapshotStrategy"),
+    PAGING("PAGING", "pagingSnapshotStrategy"),
+    JDBC("JDBC BULK INSERT", "jdbcSnapshotStrategy");
+
+    private final String description;
+    private final String beanName;
+
+    SnapshotStrategyType(String description, String beanName) {
+        this.description = description;
+        this.beanName = beanName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getBeanName() {
+        return beanName;
+    }
+}

--- a/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/StreamSnapshotStrategy.java
+++ b/back/tikkle/src/main/java/com/taesan/tikkle/domain/account/service/StreamSnapshotStrategy.java
@@ -1,0 +1,83 @@
+package com.taesan.tikkle.domain.account.service;
+
+import com.taesan.tikkle.domain.account.entity.Account;
+import com.taesan.tikkle.domain.account.entity.BalanceSnapshot;
+import com.taesan.tikkle.domain.account.repository.AccountCustomRepository;
+import com.taesan.tikkle.domain.account.repository.AccountRepository;
+import com.taesan.tikkle.domain.account.repository.BalanceSnapshotRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Component("streamSnapshotStrategy")
+@RequiredArgsConstructor
+public class StreamSnapshotStrategy implements SnapshotStrategy {
+
+    private final AccountCustomRepository accountCustomRepository;
+    private final BalanceSnapshotRepository balanceSnapshotRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private static final Logger logger = LoggerFactory.getLogger(StreamSnapshotStrategy.class);
+
+    @Override
+    public void createSnapShots() {
+        logger.info("Creating snapshots using Stream API strategy");
+
+        int fetchSize = 1000;
+        int processedCount = 0;
+
+        try (Stream<Account> accountStream = accountCustomRepository.findAllWithStream(fetchSize)) {
+            List<BalanceSnapshot> batchSnapshots = new ArrayList<>(fetchSize);
+            Iterator<Account> iterator = accountStream.iterator();
+
+            while (iterator.hasNext()) {
+                Account account = iterator.next();
+                BalanceSnapshot snapshot = convertToSnapshot(account);
+                batchSnapshots.add(snapshot);
+
+                if (batchSnapshots.size() >= fetchSize) {
+                    processedCount += batchSnapshots.size();
+                    balanceSnapshotRepository.saveAll(batchSnapshots);
+                    entityManager.flush();
+                    entityManager.clear();
+                    batchSnapshots.clear();
+                }
+            }
+
+            if (!batchSnapshots.isEmpty()) {
+                processedCount += batchSnapshots.size();
+                balanceSnapshotRepository.saveAll(batchSnapshots);
+                entityManager.flush();
+                entityManager.clear();
+            }
+        }
+
+        logger.info("Created {} snapshots using Stream API strategy", processedCount);
+    }
+
+    @Override
+    public String getStrategyName() {
+        return SnapshotStrategyType.STREAM.getDescription();
+    }
+
+    private BalanceSnapshot convertToSnapshot(Account account) {
+        return BalanceSnapshot.builder()
+                .accountId(account.getId())
+                .timeQnt(account.getTimeQnt())
+                .rankingPoint(account.getRankingPoint())
+                .build();
+    }
+}


### PR DESCRIPTION
## 계좌 스냅샷 생성 관련 전략 패턴 작성

### 요약
- 계좌 스냅샷 생성 로직을 전략 패턴을 활용하여 성능 비교 바탕 작성
  - 추후 쿼리 개선 및 영속성 관리 증명 필요 
- 일반 JPA, JPA Stream, Paging (Slice 이용), JdbcClient 이용 4가지
- JDBC 이용 시 INSERT INTO SELECT 구문을 활용한 메모리 효율적인 구현 방식 추가

### 주요 변경 사항
1. **전략 패턴 구현**  
- 계좌 스냅샷 생성을 위한 다양한 전략 인터페이스 및 구현체 추가
- 기존 ORM 기반 방식들과 JDBC 기반 직접 쿼리 방식을 전략으로 분리
- 테스트 시 런타임에 최적의 전략을 비교할 수 있는 구조 설계

2. **성능 최적화**  
- 기본 전략: JPA Repository를 사용한 기본 구현 방식
- 스트림 전략: JPA Stream을 활용한 메모리 효율적인 처리 방식
  - entityManager 이용 시 detach 처리

- 페이징 전략: JPA 페이징 처리를 통한 대용량 데이터 처리 최적화
  - Page 대신 COUNT 쿼리 없는 Slice 이용.  

- JDBC 전략: 애플리케이션 메모리 사용 없이 DB 내부에서 직접 데이터 변환 및 삽입 (accounts -> balance_snapshot)
  - 엔티티 특성에 맞게 INSERT INTO SELECT 구문을 활용하여 오버헤드 줄임

### 기능 검증
- 현재 테스트 이루어져 있지 않으며, 코드 리뷰 및 방향성 공유를 위한 1차 PR
- 이후 테스트 클래스 생성하여 작동 여부 및 성능 비교 예정

### 향후 개선점
- 각 전략별 성능 비교 테스트 추가
- 대용량 데이터에 대한 부하 테스트 및 성능 테스트 진행 예정
- 멀티스레드 환경에서의 최적화 방안 검토

## 관련 이슈
- #20 
  - 간단한 설명 및 자료에 대한 출처 역시 코멘트로 남겨놓음 
